### PR TITLE
Update minimum required version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8", "packaging>=24.2"]
+requires = ["setuptools>=71", "setuptools-scm>=8", "packaging>=24.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
`setuptools.command.bdist_wheel` is available in setuptools 71 or later (but not in 70.0.0).

Found out while building a module on SDCC (which has `setuptools` 68.2.2)